### PR TITLE
Add systemd .service file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Desc.:   Makefile for ALSA Mixer WebUI
 #
 
-INSTALL_PATH=/usr/share/amixer-webui
+INSTALL_PATH ?= /usr/share/amixer-webui
 BUILD_PATH=production/deb-package
 
 VERSION := $(shell git describe --tags | cut -c2- > .version && cat .version)

--- a/amixer-web.service
+++ b/amixer-web.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=ALSA Mixer WebUIDaemon
+After=network-online.target
+ 
+[Service]
+Type=simple
+WorkingDirectory=/usr/share/amixer-webui
+ExecStart=/usr/share/amixer-webui/alsamixer_webui.py
+ 
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
fixes #16 

The file should be put in `/etc/systemd/system`, or can be place in `/usr/share/amixer-webui` and make a symbolic link on the file in `/etc/systemd/system`. I haven't edited the Makefile as it could fail on non systemd OSes.

Nonetheless, I can add another commit to detail systemd installation if you wish.