### PR TITLE
Fix content-type for 'hostname'

### DIFF
--- a/alsamixer_webui.py
+++ b/alsamixer_webui.py
@@ -192,7 +192,9 @@ def index():
 @app.route('/hostname/')
 def get_hostname():
     """Sends server's hostname [plain text:String]"""
-    return socket.gethostname()
+    data = json.dumps(socket.gethostname())
+    resp = Response(response=data, status=200, mimetype="application/json")
+    return resp
 
 
 @app.route('/cards/')

--- a/alsamixer_webui_tests.py
+++ b/alsamixer_webui_tests.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 import socket
 import alsamixer_webui
@@ -31,7 +32,7 @@ class AlsamixerTestCase(unittest.TestCase):
     def test_GET_hostname(self):
         rv = self.app.get('/hostname/')
         assert rv.status_code == 200
-        assert rv.data.decode('ascii') == socket.gethostname()
+        assert rv.data.decode('ascii') == json.dumps(socket.gethostname())
 
     def test_GET_card(self):
         rv = self.app.get('/card/')


### PR DESCRIPTION
When running the app behind a reverse proxy (apache+mod_proxy+mod_proxy_html) I noticed that the reported host name is garbled, with extra tags around the actual host name.

This is because the content-type for the data returned by the backend for the host name isn't forced to JSON (even though the web app code does seem to expect JSON, even if just a plain string), and the middleware decides to "fix" the content.

The proposed fix is to return actual JSON with the proper content-type.